### PR TITLE
fix(windows): cross-platform CLI entry detection and stderr logging for MCP

### DIFF
--- a/index.js
+++ b/index.js
@@ -860,7 +860,8 @@ class SqlServerMCP {
 }
 
 // Main execution
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Use fileURLToPath for cross-platform compatibility (Windows vs Unix path formats)
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
   const server = new SqlServerMCP();
   server.run().catch(error => {
     // Use console.error here since logger might not be initialized yet

--- a/lib/config/server-config.js
+++ b/lib/config/server-config.js
@@ -469,7 +469,7 @@ export class ServerConfig {
   }
 
   /**
-   * Log configuration summary for MCP servers (stdout compatible)
+   * Log configuration summary for MCP servers (stderr to avoid JSON-RPC pollution)
    */
   logMcpConfiguration() {
     if (process.env.NODE_ENV === 'test') return;
@@ -489,7 +489,7 @@ export class ServerConfig {
       '===================================='
     ];
 
-    lines.forEach(line => console.log(line));
+    lines.forEach(line => console.error(line));
   }
 
   /**
@@ -777,8 +777,8 @@ export class ServerConfig {
         }
       });
     } else {
-      // Use console.log (stdout) instead of console.error (stderr) for MCP compatibility
-      console.log(configMessage);
+      // Use console.error (stderr) for MCP compatibility - avoid polluting stdout JSON-RPC channel
+      console.error(configMessage);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "warp-sql-server-mcp",
+  "name": "@egarcia74/warp-sql-server-mcp",
   "version": "1.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "warp-sql-server-mcp",
+      "name": "@egarcia74/warp-sql-server-mcp",
       "version": "1.7.12",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 📝 Description
Cross-platform improvements and MCP logging safety:
- Use `fileURLToPath(import.meta.url)` when comparing CLI entry to `process.argv[1]` to reliably detect direct execution on Windows and Unix.
- Route MCP configuration logs to `stderr` so `stdout` remains pure JSON‑RPC (per WARP.md guidance), preventing protocol pollution for MCP clients.

## 🔗 Related Issue
N/A

## 🧪 Type of Change
- [x] 🐛 Bug fix (Windows CLI entry detection)
- [x] 🔒 Security/stability improvement (keep stdout clean for JSON‑RPC)

## 🚀 What's Changed
### Changed
- `index.js`: Replace string URL compare with `fileURLToPath` compare for CLI entry detection.
- `lib/config/server-config.js`: Log configuration messages to `stderr` instead of `stdout` for MCP protocol safety.

### Fixed
- Windows direct-run detection of the CLI entry.
- Potential stdout pollution of MCP JSON‑RPC channel.

## 🧪 Testing
### Test Coverage
- [x] Unit tests pass (`npm test`)
- [x] Integration tests pass (Docker-backed SQL Server)
- [x] Performance smoke validated

### Test Details
- Verified full pre-commit and pre-push gates locally: lint, format, markdown, link check, coverage, audit.
- MCP protocol startup test passes; JSON‑RPC communication verified.

## 📦 Dependencies
- [x] No new dependencies

## 📖 Documentation
- No doc changes required. Behavior aligns with existing WARP.md guidance on MCP stdout purity.

## ⚠️ Breaking Changes
- None

## 🔍 Code Quality
- [x] Self-review completed, no debug logs left
- [x] Error handling unaffected; only stream selection changed

## 📊 Performance Impact
- [x] No performance impact

## 🔒 Security Considerations
- Keeps MCP stdout free of non‑protocol output, reducing risk of client parsing errors.

## 📋 Deployment Notes
- None
