### PR TITLE
refactor: clear pre-existing SonarCloud findings in source files

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,9 +194,7 @@ class SqlServerMCP {
 
     if (statements.length > 1) {
       // For multi-statement, find the most restrictive type
-      const types = new Set(
-        statements.map(stmt => this._getSingleQueryType(stmt, securityConfig))
-      );
+      const types = new Set(statements.map(stmt => this._getSingleQueryType(stmt, securityConfig)));
 
       if (types.has('schema')) return 'schema';
       if (types.has('destructive')) return 'destructive';

--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ import { BottleneckDetector } from './lib/analysis/bottleneck-detector.js';
 import { Logger } from './lib/utils/logger.js';
 
 // Read package.json for version info
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8'));
@@ -194,11 +194,13 @@ class SqlServerMCP {
 
     if (statements.length > 1) {
       // For multi-statement, find the most restrictive type
-      const types = statements.map(stmt => this._getSingleQueryType(stmt, securityConfig));
+      const types = new Set(
+        statements.map(stmt => this._getSingleQueryType(stmt, securityConfig))
+      );
 
-      if (types.includes('schema')) return 'schema';
-      if (types.includes('destructive')) return 'destructive';
-      if (types.includes('select')) return 'select';
+      if (types.has('schema')) return 'schema';
+      if (types.has('destructive')) return 'destructive';
+      if (types.has('select')) return 'select';
       return 'unknown';
     }
 
@@ -683,7 +685,7 @@ class SqlServerMCP {
   }
 
   async analyzeQueryPerformance(query, database) {
-    const analysis = await this.queryOptimizer.analyzeQuery(query, database);
+    const analysis = this.queryOptimizer.analyzeQuery(query, database);
     return [
       {
         type: 'text',
@@ -751,6 +753,17 @@ class SqlServerMCP {
     const performanceStats = this.performanceMonitor.getStats();
     const connectionHealth = this.getConnectionHealth();
 
+    let securityLevel;
+    if (this.readOnlyMode) {
+      securityLevel = 'MAXIMUM (Read-Only)';
+    } else if (this.allowSchemaChanges) {
+      securityLevel = 'MINIMAL (Full Access)';
+    } else if (this.allowDestructiveOperations) {
+      securityLevel = 'MEDIUM (DML Allowed)';
+    } else {
+      securityLevel = 'HIGH (DDL Blocked)';
+    }
+
     const serverInfo = {
       server: {
         name: 'warp-sql-server-mcp',
@@ -773,13 +786,7 @@ class SqlServerMCP {
           readOnlyMode: this.readOnlyMode,
           allowDestructiveOperations: this.allowDestructiveOperations,
           allowSchemaChanges: this.allowSchemaChanges,
-          securityLevel: this.readOnlyMode
-            ? 'MAXIMUM (Read-Only)'
-            : this.allowSchemaChanges
-              ? 'MINIMAL (Full Access)'
-              : this.allowDestructiveOperations
-                ? 'MEDIUM (DML Allowed)'
-                : 'HIGH (DDL Blocked)'
+          securityLevel
         },
         performance: {
           enabled: this.config.performanceMonitoring.enabled,

--- a/lib/analysis/query-optimizer.js
+++ b/lib/analysis/query-optimizer.js
@@ -699,7 +699,7 @@ export class QueryOptimizer {
     return (
       query.toUpperCase().includes('LEFT JOIN') &&
       !query.toUpperCase().includes('SELECT') &&
-      query.toUpperCase().match(/\.\*/)
+      /\.\*/.test(query.toUpperCase())
     );
   }
 

--- a/lib/config/secret-manager.js
+++ b/lib/config/secret-manager.js
@@ -26,12 +26,12 @@ export class SecretManager {
    * @private
    */
   _safeParseInt(secretValue, defaultValue, min = 0, max = Number.MAX_SAFE_INTEGER) {
-    const value = parseInt(secretValue || defaultValue);
-    if (isNaN(value) || value < min || value > max) {
+    const value = Number.parseInt(secretValue || defaultValue);
+    if (Number.isNaN(value) || value < min || value > max) {
       console.warn(
         `Invalid integer value from secret: ${secretValue}, using default: ${defaultValue}`
       );
-      return parseInt(defaultValue);
+      return Number.parseInt(defaultValue);
     }
     return value;
   }

--- a/lib/config/server-config.js
+++ b/lib/config/server-config.js
@@ -674,11 +674,7 @@ export class ServerConfig {
         `    Sampling Rate: ${this.performanceMonitoring.samplingRate * 100}%`
       );
     }
-    configLines.push(
-      '',
-      '📊 Streaming Configuration:',
-      `    Enabled: ${this.streaming.enabled}`
-    );
+    configLines.push('', '📊 Streaming Configuration:', `    Enabled: ${this.streaming.enabled}`);
     if (this.streaming.enabled) {
       configLines.push(
         `    Batch Size: ${this.streaming.batchSize} rows`,

--- a/lib/config/server-config.js
+++ b/lib/config/server-config.js
@@ -5,10 +5,10 @@
  * Provides a clean interface for accessing server settings
  */
 
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -40,10 +40,10 @@ export class ServerConfig {
    * @private
    */
   _safeParseInt(envVar, defaultValue, min = 0, max = Number.MAX_SAFE_INTEGER) {
-    const value = parseInt(envVar || defaultValue);
-    if (isNaN(value) || value < min || value > max) {
+    const value = Number.parseInt(envVar || defaultValue);
+    if (Number.isNaN(value) || value < min || value > max) {
       console.warn(`Invalid integer value: ${envVar}, using default: ${defaultValue}`);
-      return parseInt(defaultValue);
+      return Number.parseInt(defaultValue);
     }
     return value;
   }
@@ -58,10 +58,10 @@ export class ServerConfig {
    * @private
    */
   _safeParseFloat(envVar, defaultValue, min = 0, max = Number.MAX_VALUE) {
-    const value = parseFloat(envVar || defaultValue);
-    if (isNaN(value) || value < min || value > max) {
+    const value = Number.parseFloat(envVar || defaultValue);
+    if (Number.isNaN(value) || value < min || value > max) {
       console.warn(`Invalid float value: ${envVar}, using default: ${defaultValue}`);
-      return parseFloat(defaultValue);
+      return Number.parseFloat(defaultValue);
     }
     return value;
   }
@@ -102,7 +102,7 @@ export class ServerConfig {
       maxMetricsHistory: this._safeParseInt(process.env.MAX_METRICS_HISTORY, '1000', 100, 10000),
       slowQueryThreshold: this._safeParseInt(process.env.SLOW_QUERY_THRESHOLD, '5000', 100, 60000),
       trackPoolMetrics: process.env.TRACK_POOL_METRICS !== 'false', // Default: true
-      samplingRate: this._safeParseFloat(process.env.PERFORMANCE_SAMPLING_RATE, '1.0', 0.0, 1.0)
+      samplingRate: this._safeParseFloat(process.env.PERFORMANCE_SAMPLING_RATE, '1.0', 0, 1)
     };
 
     // Streaming configuration
@@ -350,7 +350,7 @@ export class ServerConfig {
     const isPrivateIP =
       host.startsWith('192.168.') ||
       host.startsWith('10.') ||
-      /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(host);
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
 
     if (isPrivateIP) {
       if (isExplicitDev) {
@@ -507,28 +507,32 @@ export class ServerConfig {
     configLines.push('=== SQL Server MCP Configuration ===');
 
     // MCP Server Information
-    configLines.push('🖥️  MCP Server Information:');
-    configLines.push(`    Name: ${packageJson.name}`);
-    configLines.push(`    Version: ${packageJson.version}`);
-    configLines.push(`    Description: ${packageJson.description}`);
-    configLines.push('');
+    configLines.push(
+      '🖥️  MCP Server Information:',
+      `    Name: ${packageJson.name}`,
+      `    Version: ${packageJson.version}`,
+      `    Description: ${packageJson.description}`,
+      ''
+    );
 
     // Runtime Environment
-    configLines.push('⚙️  Runtime Environment:');
-    configLines.push(`    Node.js: ${process.version}`);
-    configLines.push(`    Platform: ${process.platform}`);
-    configLines.push(`    Architecture: ${process.arch}`);
-    configLines.push(`    Process ID: ${process.pid}`);
-    configLines.push(`    Parent Process ID: ${process.ppid || 'unknown'}`);
-    configLines.push(`    Working Directory: ${process.cwd()}`);
-    configLines.push(`    Environment: ${process.env.NODE_ENV || 'development'}`);
+    configLines.push(
+      '⚙️  Runtime Environment:',
+      `    Node.js: ${process.version}`,
+      `    Platform: ${process.platform}`,
+      `    Architecture: ${process.arch}`,
+      `    Process ID: ${process.pid}`,
+      `    Parent Process ID: ${process.ppid || 'unknown'}`,
+      `    Working Directory: ${process.cwd()}`,
+      `    Environment: ${process.env.NODE_ENV || 'development'}`
+    );
 
     // Memory and system info
     const memUsage = process.memoryUsage();
     configLines.push(
-      `    Memory Usage: ${Math.round(memUsage.rss / 1024 / 1024)}MB RSS, ${Math.round(memUsage.heapUsed / 1024 / 1024)}MB Heap`
+      `    Memory Usage: ${Math.round(memUsage.rss / 1024 / 1024)}MB RSS, ${Math.round(memUsage.heapUsed / 1024 / 1024)}MB Heap`,
+      `    Uptime: ${Math.round(process.uptime())}s`
     );
-    configLines.push(`    Uptime: ${Math.round(process.uptime())}s`);
 
     // Command line arguments
     const args = process.argv.slice(2);
@@ -560,14 +564,15 @@ export class ServerConfig {
       configLines.push(`    Key Env Vars: ${setEnvVars.join(', ')}`);
     }
 
-    configLines.push('');
-
-    configLines.push('🌐 Connection Settings:');
-    configLines.push(`    Server: ${connectionSummary.server}`);
-    configLines.push(`    Database: ${connectionSummary.database}`);
-    configLines.push(`    Auth Type: ${connectionSummary.authType}`);
-    configLines.push(`    User: ${connectionSummary.user}`);
-    configLines.push('    Password: ***********');
+    configLines.push(
+      '',
+      '🌐 Connection Settings:',
+      `    Server: ${connectionSummary.server}`,
+      `    Database: ${connectionSummary.database}`,
+      `    Auth Type: ${connectionSummary.authType}`,
+      `    User: ${connectionSummary.user}`,
+      '    Password: ***********'
+    );
     if (connectionSummary.authType === 'Windows Authentication') {
       configLines.push(`    Domain: ${connectionSummary.domain}`);
     }
@@ -597,28 +602,23 @@ export class ServerConfig {
     configLines.push(`    Security Decision: ${securityDecision.reason}`);
     if (securityDecision.type === 'auto-detected') {
       configLines.push(`    Detection Confidence: ${securityDecision.confidence}`);
-      if (securityDecision.warnings && securityDecision.warnings.length > 0) {
+      if (securityDecision.warnings?.length > 0) {
         configLines.push(`    ⚠️  Warnings: ${securityDecision.warnings.join(', ')}`);
       }
     }
     configLines.push(
-      `    Security Level: ${securityDecision.securityLevel === 'high' ? '🔒 High' : '⚠️  Low'}`
-    );
-
-    configLines.push(
-      `    Environment: ${connectionSummary.isDevEnvironment ? '🔧 Development' : '🏭 Production'} (${securityDecision.type === 'auto-detected' ? 'auto-detected' : 'explicit'})`
-    );
-    configLines.push(
+      `    Security Level: ${securityDecision.securityLevel === 'high' ? '🔒 High' : '⚠️  Low'}`,
+      `    Environment: ${connectionSummary.isDevEnvironment ? '🔧 Development' : '🏭 Production'} (${securityDecision.type === 'auto-detected' ? 'auto-detected' : 'explicit'})`,
       `    Pool: ${connectionSummary.poolMin}-${connectionSummary.poolMax} connections`
     );
 
     // Network and timing diagnostics
-    configLines.push('');
-    configLines.push('🔧 Network & Timing Diagnostics:');
     configLines.push(
-      `    Connection String Length: ${this.getConnectionConfig().connectionString?.length || 0} chars`
+      '',
+      '🔧 Network & Timing Diagnostics:',
+      `    Connection String Length: ${this.getConnectionConfig().connectionString?.length || 0} chars`,
+      `    Hostname Resolution: ${os.hostname()}`
     );
-    configLines.push(`    Hostname Resolution: ${os.hostname()}`);
 
     // Try to get network interface info (best effort)
     try {
@@ -637,13 +637,13 @@ export class ServerConfig {
     if (connectionSummary.encrypt && connectionManager) {
       const health = connectionManager.getConnectionHealth();
       if (health.ssl) {
-        configLines.push('');
-        configLines.push('🔐 SSL Connection Information:');
-        configLines.push(`    Status: ${health.ssl.connection_status}`);
-        configLines.push(`    Protocol: ${health.ssl.protocol}`);
-        configLines.push(`    Server: ${health.ssl.server}`);
-        configLines.push(`    Encryption: ${health.ssl.encrypt ? 'Enabled' : 'Disabled'}`);
         configLines.push(
+          '',
+          '🔐 SSL Connection Information:',
+          `    Status: ${health.ssl.connection_status}`,
+          `    Protocol: ${health.ssl.protocol}`,
+          `    Server: ${health.ssl.server}`,
+          `    Encryption: ${health.ssl.encrypt ? 'Enabled' : 'Disabled'}`,
           `    Trust Server Certificate: ${health.ssl.trust_server_certificate ? 'Yes' : 'No'}`
         );
         if (health.ssl.note) {
@@ -652,49 +652,50 @@ export class ServerConfig {
       }
     }
 
-    configLines.push('');
-    configLines.push('🔒 Security & Operation Settings:');
-    configLines.push(`    Debug Mode: ${this.debugMode}`);
-    configLines.push(`    Read-Only Mode: ${this.readOnlyMode ? '🔒' : '🔓'} ${this.readOnlyMode}`);
     configLines.push(
-      `    Allow Destructive Operations: ${this.allowDestructiveOperations ? '⚠️' : '✅'} ${this.allowDestructiveOperations}`
+      '',
+      '🔒 Security & Operation Settings:',
+      `    Debug Mode: ${this.debugMode}`,
+      `    Read-Only Mode: ${this.readOnlyMode ? '🔒' : '🔓'} ${this.readOnlyMode}`,
+      `    Allow Destructive Operations: ${this.allowDestructiveOperations ? '⚠️' : '✅'} ${this.allowDestructiveOperations}`,
+      `    Allow Schema Changes: ${this.allowSchemaChanges ? '⚠️' : '✅'} ${this.allowSchemaChanges}`,
+      `    Connection Timeout: ${this.connectionTimeout}ms`,
+      `    Request Timeout: ${this.requestTimeout}ms`,
+      `    Max Retries: ${this.maxRetries}`,
+      '',
+      '⚡ Performance Monitoring:',
+      `    Enabled: ${this.performanceMonitoring.enabled}`
     );
-    configLines.push(
-      `    Allow Schema Changes: ${this.allowSchemaChanges ? '⚠️' : '✅'} ${this.allowSchemaChanges}`
-    );
-    configLines.push(`    Connection Timeout: ${this.connectionTimeout}ms`);
-    configLines.push(`    Request Timeout: ${this.requestTimeout}ms`);
-    configLines.push(`    Max Retries: ${this.maxRetries}`);
-    configLines.push('');
-    configLines.push('⚡ Performance Monitoring:');
-    configLines.push(`    Enabled: ${this.performanceMonitoring.enabled}`);
     if (this.performanceMonitoring.enabled) {
-      configLines.push(`    Max History: ${this.performanceMonitoring.maxMetricsHistory} records`);
       configLines.push(
-        `    Slow Query Threshold: ${this.performanceMonitoring.slowQueryThreshold}ms`
+        `    Max History: ${this.performanceMonitoring.maxMetricsHistory} records`,
+        `    Slow Query Threshold: ${this.performanceMonitoring.slowQueryThreshold}ms`,
+        `    Track Pool Metrics: ${this.performanceMonitoring.trackPoolMetrics}`,
+        `    Sampling Rate: ${this.performanceMonitoring.samplingRate * 100}%`
       );
-      configLines.push(`    Track Pool Metrics: ${this.performanceMonitoring.trackPoolMetrics}`);
-      configLines.push(`    Sampling Rate: ${this.performanceMonitoring.samplingRate * 100}%`);
     }
-    configLines.push('');
-    configLines.push('📊 Streaming Configuration:');
-    configLines.push(`    Enabled: ${this.streaming.enabled}`);
+    configLines.push(
+      '',
+      '📊 Streaming Configuration:',
+      `    Enabled: ${this.streaming.enabled}`
+    );
     if (this.streaming.enabled) {
-      configLines.push(`    Batch Size: ${this.streaming.batchSize} rows`);
-      configLines.push(`    Memory Limit: ${this.streaming.maxMemoryMB}MB`);
       configLines.push(
+        `    Batch Size: ${this.streaming.batchSize} rows`,
+        `    Memory Limit: ${this.streaming.maxMemoryMB}MB`,
         `    Response Size Limit: ${Math.round(this.streaming.maxResponseSize / 1048576)}MB`
       );
     }
-    configLines.push('');
-    configLines.push('📝 Logging & Output:');
-    configLines.push(`    Log Level: ${this.logging.logLevel}`);
-    configLines.push(`    Security Audit: ${this.logging.securityAudit}`);
-    configLines.push(`    Response Format: ${this.logging.responseFormat}`);
+    configLines.push(
+      '',
+      '📝 Logging & Output:',
+      `    Log Level: ${this.logging.logLevel}`,
+      `    Security Audit: ${this.logging.securityAudit}`,
+      `    Response Format: ${this.logging.responseFormat}`
+    );
 
     // Add dependency and module information for troubleshooting
-    configLines.push('');
-    configLines.push('📦 Dependencies & Modules:');
+    configLines.push('', '📦 Dependencies & Modules:');
 
     // Key dependency versions from package.json
     try {
@@ -713,18 +714,17 @@ export class ServerConfig {
 
     // Module loading information
     configLines.push(
-      `    Total Modules Loaded: ${Object.keys(process.moduleLoadList || []).length}`
+      `    Total Modules Loaded: ${Object.keys(process.moduleLoadList || []).length}`,
+      '    MCP Protocol: Model Context Protocol',
+      '    Transport: stdio (stdin/stdout)'
     );
-    configLines.push('    MCP Protocol: Model Context Protocol');
-    configLines.push('    Transport: stdio (stdin/stdout)');
 
     // Add log file paths if logger is available
-    if (logger && logger.config) {
+    if (logger?.config) {
       const logConfig = logger.config;
       const logDefaults = logger._getSmartLogDefaults();
 
-      configLines.push('');
-      configLines.push('📁 Log File Locations:');
+      configLines.push('', '📁 Log File Locations:');
 
       if (logConfig.logFile || logDefaults.logFile) {
         const mainLogPath = logConfig.logFile || logDefaults.logFile;

--- a/lib/database/connection-manager.js
+++ b/lib/database/connection-manager.js
@@ -36,10 +36,10 @@ export class ConnectionManager {
    * @private
    */
   _safeParseInt(envVar, defaultValue, min = 0, max = Number.MAX_SAFE_INTEGER) {
-    const value = parseInt(envVar || defaultValue);
-    if (isNaN(value) || value < min || value > max) {
+    const value = Number.parseInt(envVar || defaultValue);
+    if (Number.isNaN(value) || value < min || value > max) {
       console.warn(`Invalid integer value: ${envVar}, using default: ${defaultValue}`);
-      return parseInt(defaultValue);
+      return Number.parseInt(defaultValue);
     }
     return value;
   }

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,8 +1,8 @@
 import winston from 'winston';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-import { execSync } from 'child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
 
 /**
  * Enhanced Logging System with Security Audit Capabilities
@@ -71,7 +71,7 @@ export class Logger {
               .map(line => {
                 // Enhanced formatting for better visual structure
                 const trimmed = line.trim();
-                if (trimmed.match(/^(🌐|🔒|⚡|📊|📝|🖥️|⚙️)/u)) {
+                if (/^(🌐|🔒|⚡|📊|📝|🖥️|⚙️)/u.test(trimmed)) {
                   // Section headers - clean hierarchical style with underline
                   const headerText = trimmed.replace(':', '');
                   const underline = '─'.repeat(headerText.length);
@@ -107,8 +107,8 @@ export class Logger {
 
           // Handle other multi-line messages properly
           let formattedMessage = message;
-          if (typeof message === 'string' && message.includes('\\n')) {
-            formattedMessage = message.replace(/\\n/g, '\n');
+          if (typeof message === 'string' && message.includes(String.raw`\n`)) {
+            formattedMessage = message.replaceAll(String.raw`\n`, '\n');
           }
 
           // Format metadata normally for other messages
@@ -314,7 +314,7 @@ export class Logger {
         const isOurPackage =
           packageJson.name === '@egarcia74/warp-sql-server-mcp' ||
           packageJson.name === 'warp-sql-server-mcp';
-        const hasTestScript = !!(packageJson.scripts && packageJson.scripts.test);
+        const hasTestScript = !!packageJson.scripts?.test;
         return isOurPackage || hasTestScript;
       }
     } catch {

--- a/lib/utils/streaming-handler.js
+++ b/lib/utils/streaming-handler.js
@@ -350,7 +350,7 @@ export class StreamingHandler {
               if (Array.isArray(parsedData)) {
                 allRows.push(...parsedData);
               } else {
-                throw new Error('Parsed JSON data is not an array');
+                throw new TypeError('Parsed JSON data is not an array');
               }
             } catch (error) {
               throw new Error(`Invalid JSON chunk data: ${error.message}`, { cause: error });
@@ -416,7 +416,7 @@ export class StreamingHandler {
    */
   _safeJsonParse(jsonString) {
     if (typeof jsonString !== 'string') {
-      throw new Error('Input must be a string');
+      throw new TypeError('Input must be a string');
     }
 
     // Check for reasonable size limits (prevent DoS via large JSON)
@@ -453,7 +453,7 @@ export class StreamingHandler {
     }
 
     // Check for prototype pollution attempts
-    const dangerousKeys = ['__proto__', 'constructor', 'prototype'];
+    const dangerousKeys = new Set(['__proto__', 'constructor', 'prototype']);
 
     if (Array.isArray(obj)) {
       for (const item of obj) {
@@ -461,7 +461,7 @@ export class StreamingHandler {
       }
     } else {
       for (const key in obj) {
-        if (dangerousKeys.includes(key)) {
+        if (dangerousKeys.has(key)) {
           throw new Error(`Potentially dangerous JSON key detected: ${key}`);
         }
 


### PR DESCRIPTION
## Summary

Mechanical, **behavior-preserving** cleanup of older (pre-existing) SonarCloud code smells in production source code. No test, script, or SQL files touched. Unit suite green (540/540), lint clean.

These are the "older findings" tech-debt items that were explicitly deferred from PR #695 — none were blocking the new-code quality gate; this pays them down ahead of a release.

## Rules addressed (source files only)

| Rule | Fix |
|------|-----|
| S7772 | `node:` protocol for builtin imports (fs/path/os/url/child_process) |
| S7773 | `Number.parseInt/parseFloat/isNaN` over globals |
| S7778 | consolidate consecutive `Array#push()` into multi-arg calls (`server-config`) |
| S7776 | array `.includes()` membership → `Set` + `.has()` (`index`, `streaming-handler`) |
| S7786 | `TypeError` over `Error` for argument-type failures (`streaming-handler`) |
| S7780 / S7781 | `String.raw` + `replaceAll` (`logger`) |
| S6353 / S6582 / S6594 / S7748 | `\d` class, optional chaining, `RegExp.exec`, drop zero-fraction |
| S3358 | extract nested `securityLevel` ternary into an `if/else` chain (`index`) |
| S3800 | `canUseExists` now always returns boolean (was `boolean \| Array \| null`) |
| S4123 | drop unnecessary `await` on the synchronous `analyzeQuery`; the `await` on the **async** `getOptimizationInsights` is correct → marked false-positive in Sonar |

## Notably genuine (not just cosmetic)
- **S3800** (`canUseExists`): the final `&&` operand was `.match(/\.\*/)` → returned `Array | null`, making the function return three types. Now returns boolean consistently.
- **S4123** (`analyzeQuery`): the method is synchronous, so the `await` was on a non-Promise — removed.

## Deferred (intentionally not in this PR)
- **S3776** cognitive-complexity refactors (`server-config`, `connection-manager`, several test helpers) — real structural refactors, too risky for a mechanical cleanup PR.
- All `test/`, `test/docker/`, `scripts/`, and SQL (`init-db.sql`) findings.

## Verification
- `npm run lint` — clean
- `npm run test:unit` — 540/540 passing
- Full integration suite runs in CI (local Docker conflicts with a persistent dev container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)