### PR TITLE
docs(ci): correct codecov-action version comment v5 → v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           directory: ./coverage
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
The pinned SHA `e79a6962e0d4c0c17b229090214935d2e33f8354` for `codecov/codecov-action` is **v6.0.1** (verified against the upstream tag), but the inline version comment still read `# v5` — a stale label carried over when Dependabot bumped the SHA (PR #662) without updating the comment.

This corrects the comment to `# v6` so it accurately reflects the pinned release. **No functional change** — only a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)