### PR TITLE
chore(npm): add files allowlist + CLI --version command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,7 @@ Commands:
   start              Start the MCP server
   init               Initialize configuration file
   config             Show current configuration
+  version, --version, -v   Show the installed version
   help, --help, -h   Show this help message
 
 Examples:
@@ -53,6 +54,18 @@ Configuration:
   After running 'init', edit the config file with your SQL Server details.
   The server will use environment variables first, then fall back to config file.
 `);
+}
+
+function showVersion() {
+  // Read the version from this package's package.json (resolved relative to
+  // this file so it works regardless of the install location).
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+    console.log(`${pkg.name} v${pkg.version}`);
+  } catch (error) {
+    console.error(`❌ Failed to read version: ${error.message}`);
+    process.exit(1);
+  }
 }
 
 function initConfig() {
@@ -191,6 +204,11 @@ switch (command) {
     break;
   case 'config':
     showConfig();
+    break;
+  case 'version':
+  case '--version':
+  case '-v':
+    showVersion();
     break;
   case 'help':
   case '--help':

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "bin": {
     "warp-sql-server-mcp": "cli.js"
   },
+  "files": [
+    "index.js",
+    "cli.js",
+    "lib/",
+    "docs/*.md",
+    "docs/*.html",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "start": "node index.js",
     "dev": "node --watch index.js",

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -148,4 +148,22 @@ describe('CLI Security Tests', () => {
     expect(stdout).toContain('Usage:');
     expect(stdout).toContain('Commands:');
   });
+
+  test('should print the package version with --version', async () => {
+    const proc = spawn('node', [CLI_PATH, '--version'], { stdio: 'pipe' });
+
+    let stdout = '';
+    proc.stdout.on('data', data => {
+      stdout += data.toString();
+    });
+
+    const exitCode = await new Promise(resolve => {
+      proc.on('close', resolve);
+    });
+
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'));
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(pkg.version);
+    expect(stdout).toContain('@egarcia74/warp-sql-server-mcp');
+  });
 });


### PR DESCRIPTION
## Summary
Two small distribution-quality fixes, prompted by the v1.7.14 release.

### 1. `files` allowlist in package.json
Previously there was **no `files` field**, so `npm publish` shipped whatever wasn't ignored — including local **`logs/*.log`** (runtime artifacts, with a config dump), `.continue/`, `.vscode/`, `.copilotignore`, `*.code-workspace`, `codex-mcp-config.json`, etc. This required a manual `rm -f logs/*.log` before every publish.

Now only the package's real payload ships:
- `index.js`, `cli.js`, `lib/` — runtime code
- `docs/*.md`, `docs/*.html` — user docs (globs, **not** `docs/` — so the gitignored generated `docs/coverage/` tree isn't force-included)
- `CHANGELOG.md`, `README.md`, `LICENSE`

**Tarball: 60 → 51 files**, and logs/coverage/dev-junk are permanently excluded — deterministic regardless of local working-tree state.

> ⚠️ Note: with a `files` allowlist, `.gitignore`/`.npmignore` can no longer exclude anything *inside* a listed path — that's why `docs/` is globbed, not listed wholesale.

### 2. `--version` CLI command
The CLI had no way to report its version (`warp-sql-server-mcp --version` did nothing). Added `version` / `--version` / `-v`:
```
$ warp-sql-server-mcp --version
@egarcia74/warp-sql-server-mcp v1.7.14
```
Added to the help text and covered by a unit test.

## Verification
- `npm run format:check`, `npm run lint` — clean
- `npm run test:unit` — 542 passing (+1 new `--version` test)
- `npm publish --dry-run` — 51 files, no logs/coverage/dev artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)