### PR TITLE
[codex] update CodeQL actions to 4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -59,7 +59,7 @@ jobs:
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
     # Manual build steps if autobuild fails
     # - name: Manual build
@@ -68,7 +68,7 @@ jobs:
     #     # Add your build commands here
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         category: "/language:${{matrix.language}}"
         # Upload results even if there are vulnerabilities

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -69,6 +69,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- update `github/codeql-action/init`, `autobuild`, and `analyze` together to v4.37.3
- update the Scorecard workflow's `upload-sarif` action to the same pinned v4.37.3 commit
- supersede Dependabot PRs #955, #956, #957, and #959 with one atomic update

## Why

The individual Dependabot PRs update one CodeQL component at a time. CodeQL rejects those mixed-version workflows with: `Loaded a configuration file for version '4.37.0', but running version '4.37.3'`.

Updating every CodeQL component together removes that configuration mismatch.

## Validation

- workflow YAML parsed successfully
- 542 unit tests passed
- all Docker integration phases passed (20 read-only, 10 DML, 10 DDL)
- MCP protocol startup test passed
- performance suite passed (8/8 requests)

## Known baseline issue

`npm audit --audit-level=high` still reports existing transitive dependency advisories. Those are unrelated to this workflow-only diff and are being handled by the open dependency PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security analysis workflows to use newer CodeQL action versions.
  * Updated security scan result uploads while preserving existing workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->