### PR TITLE
ci: update CodeQL actions to 4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -59,7 +59,7 @@ jobs:
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     # Manual build steps if autobuild fails
     # - name: Manual build
@@ -68,7 +68,7 @@ jobs:
     #     # Add your build commands here
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:${{matrix.language}}"
         # Upload results even if there are vulnerabilities


### PR DESCRIPTION
## Summary

- update `github/codeql-action/init`, `autobuild`, and `analyze` together from 4.37.3 to 4.37.6
- keep all CodeQL components pinned to the same release SHA
- replace the independent updates in #1023, #1024, and #1025, which fail because mixed CodeQL Action versions cannot share configuration

## Root cause

Each Dependabot PR updates only one CodeQL component. CodeQL initializes configuration with one Action version and rejects subsequent steps running a different version.

## Test plan

- verified all three CodeQL references use SHA `5595ccaf912efad79be6eef63a5619ff05969be3` with `v4.37.6` annotations
- parsed `.github/workflows/codeql.yml` as YAML
- ran the full unit, integration, MCP protocol, and performance test suite
- passed the repository pre-push checks: coverage, security audit, ESLint, Prettier, Markdown lint, and link checking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL workflow actions to a newer patch version.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->