### PR TITLE
ci: disable npm lifecycle scripts when publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,7 +27,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Check if this is a release version bump
         id: check


### PR DESCRIPTION
## Summary

- install npm publish dependencies with `--ignore-scripts`
- prevent third-party lifecycle scripts from running in the release job
- resolve SonarCloud rule `githubactions:S6505`

## Verification

- security invariant for the publish workflow
- YAML syntax and Prettier checks
- 542 unit tests
- full Docker integration, MCP protocol, and performance suites
- coverage: 569 tests, 75.85% lines
- dependency audit: 0 vulnerabilities
- ESLint, Markdown lint, and link checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to install dependencies without running installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->