### PR TITLE
docs: clarify Codacy analysis workflow

### DIFF
--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -24,7 +24,8 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 ## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
 
 - Ask the user, "Codacy CLI is not installed. Would you like me to install it now?"
-- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task.
+- If the user responds with "yes", run the `codacy_cli_install` tool. After installation succeeds,
+  retry the interrupted `codacy_cli_analyze` call with the original arguments, then continue with the original task.
 - If the user responds with "no", explain that automatic analysis can be disabled in the extension settings.
 - Wait for the user to respond before proceeding with any other actions.
 

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -15,28 +15,38 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - `rootPath`: set to the workspace path
 - `file`: set to the path of the edited file
 - `tool`: leave empty or unset
+- Compare results with a baseline captured before editing when one is available, and distinguish pre-existing findings from findings introduced by the edit.
 - If any issues are found in the new edits, propose and apply fixes for them.
+- Limit the fix-and-reanalyze cycle to three attempts per edited file.
+- Stop retrying when the findings remain unchanged, or when the retry limit is reached, and report any unresolved findings to the user.
 - > NOTE: Failure to follow this rule is considered a critical error.
+
+## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
+
+- Ask the user, "Codacy CLI is not installed. Would you like me to install it now?"
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task.
+- If the user responds with "no", explain that automatic analysis can be disabled in the extension settings.
+- Wait for the user to respond before proceeding with any other actions.
 
 ## After every response
 
-- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server.
 
 ## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
 
 - Suggest the user the following troubleshooting steps:
-- Try to reset the MCP on the extension
-- If the user is using VSCode, suggest them to review their Copilot > MCP
-  settings in Github, under their organization or personal account. Refer them
+- Try to reset the MCP on the extension.
+- If the user is using VSCode, suggest they review their Copilot > MCP
+  settings in GitHub, under their organization or personal account. Refer them
   to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL
   (<https://github.com/settings/copilot/features>) or
   `https://github.com/organizations/{organization-name}/settings/copilot/features`
-  (This can only be done by their organization admins / owners)
-- If none of the above steps work, suggest the user to contact Codacy support
+  (This can only be done by their organization admins or owners.)
+- If none of the above steps work, suggest the user contact Codacy support.
 
 ## Trying to call a tool that needs a rootPath as a parameter
 
-- Always use the standard, non-URL-encoded file system path
+- Always use the standard, non-URL-encoded file system path.
 
 ## CRITICAL: Dependencies and Security Checks
 
@@ -52,9 +62,13 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - `tool`: set to "trivy"
 - `file`: leave empty or unset
 - If any vulnerabilities are found because of the newly added packages:
-- Stop all other operations
-- Propose and apply fixes for the security issues
-- Only continue with the original task after security issues are resolved
+- Stop all other operations.
+- Propose and apply fixes for the security issues.
+- Only continue with the original task after security issues are resolved.
+- If a vulnerability is a false positive or no patched version exists:
+  - Report its severity, affected scope, and available mitigation to the user.
+  - Ask for explicit approval to accept the residual risk and continue.
+  - Continue only after receiving that approval, and document the accepted risk and mitigation.
 - EXAMPLE:
 - After: npm install react-markdown
 - Do: Run codacy_cli_analyze with trivy
@@ -66,16 +80,17 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
 - You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
 - Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
+- Complexity metrics are different from complexity issues. When fixing complexity in a repository or file, focus on the complexity issues and ignore the metric.
 - Do not run `codacy_cli_analyze` looking for changes in code coverage.
 - Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
-- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
+- If the Codacy CLI is not installed, follow the Codacy MCP installation workflow described above.
 - When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
 
 ## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
 
-- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
-- If the user accepts, run the `codacy_setup_repository` tool
-- Do not ever try to run the `codacy_setup_repository` tool on your own
-- After setup, immediately retry the action that failed (only retry once)
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy.
+- If the user accepts, run the `codacy_setup_repository` tool.
+- Do not ever try to run the `codacy_setup_repository` tool on your own.
+- After setup, immediately retry the action that failed (only retry once).
 
 ---


### PR DESCRIPTION
## Summary

- compare post-edit Codacy findings with an available baseline and distinguish new findings from existing ones
- bound fix-and-reanalyze loops and report unchanged or unresolved findings
- document the MCP-managed Codacy CLI installation and residual-risk approval workflows
- clarify complexity-issue handling and clean up ambiguous wording

## Why

The existing instructions did not define a retry boundary, baseline comparison, or an approval path for accepted dependency risk. They also contained installation guidance that became contradictory once the MCP installation workflow was added.

## Impact

This changes agent guidance only. Runtime application behavior and dependencies are unchanged.

## Test plan

- Codacy CLI analysis of `.github/instructions/codacy.instructions.md` (no findings)
- Prettier check
- Markdown lint
- full pre-commit and pre-push suites, including 542 unit tests, integration/security tests, MCP protocol test, performance tests, 569 coverage tests, audit, lint, formatting, and link checks
