### PR TITLE
ci: group CodeQL action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,7 +125,7 @@ updates:
       # 🔒 Security-focused actions (require manual review)
       security-actions:
         patterns:
-          - "github/codeql-action"
+          - "github/codeql-action/*"
           - "ossf/scorecard-action"
           - "step-security/*"
         update-types:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -59,7 +59,7 @@ jobs:
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
     # Manual build steps if autobuild fails
     # - name: Manual build
@@ -68,7 +68,7 @@ jobs:
     #     # Add your build commands here
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         category: "/language:${{matrix.language}}"
         # Upload results even if there are vulnerabilities

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ test/docker/docker-compose.yml
 
 # Superpowers agent working docs (plans) — kept locally, not in repo
 docs/superpowers/
+
+# Local Git worktrees
+.worktrees/

--- a/test/unit/dependabot-config.test.js
+++ b/test/unit/dependabot-config.test.js
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+function extractGroupPatterns(config, groupName) {
+  const lines = config.split(/\r?\n/);
+  const patterns = [];
+  let groupIndent = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const indent = line.length - line.trimStart().length;
+
+    if (trimmed === `${groupName}:`) {
+      groupIndent = indent;
+      continue;
+    }
+
+    if (groupIndent === null) {
+      continue;
+    }
+
+    if (trimmed && indent <= groupIndent) {
+      break;
+    }
+
+    const listItem = trimmed.match(/^-\s+["']?([^"']+?)["']?$/);
+    if (listItem?.[1].startsWith('github/codeql-action')) {
+      patterns.push(listItem[1]);
+    }
+  }
+
+  return patterns;
+}
+
+function matchesDependabotPattern(pattern, dependency) {
+  const expression = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replaceAll('*', '.*');
+
+  return new RegExp(`^${expression}$`).test(dependency);
+}
+
+async function readCodeqlActions(repositoryRoot) {
+  const workflowsDirectory = path.join(repositoryRoot, '.github', 'workflows');
+  const workflowFiles = (await fs.readdir(workflowsDirectory)).filter(
+    file => file.endsWith('.yml') || file.endsWith('.yaml')
+  );
+  const actions = [];
+
+  for (const workflowFile of workflowFiles) {
+    const workflow = await fs.readFile(path.join(workflowsDirectory, workflowFile), 'utf8');
+    for (const match of workflow.matchAll(/uses:\s*github\/codeql-action\/([^@\s]+)@([^\s#]+)/g)) {
+      actions.push({ dependency: `github/codeql-action/${match[1]}`, ref: match[2] });
+    }
+  }
+
+  return actions;
+}
+
+describe('Dependabot GitHub Actions grouping', () => {
+  test('groups every CodeQL workflow action into the security update', async () => {
+    const repositoryRoot = process.cwd();
+    const codeqlActions = await readCodeqlActions(repositoryRoot);
+    const codeqlDependencies = new Set(codeqlActions.map(action => action.dependency));
+
+    const dependabotConfig = await fs.readFile(
+      path.join(repositoryRoot, '.github', 'dependabot.yml'),
+      'utf8'
+    );
+    const securityPatterns = extractGroupPatterns(dependabotConfig, 'security-actions');
+    const ungroupedDependencies = [...codeqlDependencies].filter(
+      dependency => !securityPatterns.some(pattern => matchesDependabotPattern(pattern, dependency))
+    );
+
+    expect(codeqlDependencies.size).toBeGreaterThan(0);
+    expect(ungroupedDependencies).toEqual([]);
+  });
+
+  test('pins every CodeQL workflow action to the same ref', async () => {
+    const codeqlActions = await readCodeqlActions(process.cwd());
+    const codeqlRefs = new Set(codeqlActions.map(action => action.ref));
+
+    expect(codeqlActions.length).toBeGreaterThan(0);
+    expect(codeqlRefs.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## 📝 Description

Aligns every CodeQL action with v4.37.7 and fixes Dependabot grouping so future CodeQL sub-action updates are raised together.

## 🔗 Related Pull Requests

Supersedes #1047, #1048, and #1049.

## 🧪 Type of Change

- [x] 🔒 Security improvement
- [x] 🔨 DevOps/Build changes

## 🚀 What Changed

- Updated CodeQL `init`, `autobuild`, and `analyze` to the v4.37.7 commit SHA.
- Changed the Dependabot group pattern to `github/codeql-action/*`.
- Added `.worktrees/` to `.gitignore`.
- Added regression coverage for grouping all CodeQL sub-actions and enforcing one shared ref.

## 🧪 Testing

- [x] Unit tests pass: 544 tests
- [x] Integration tests pass
- [x] MCP protocol tests pass
- [x] Performance tests pass
- [x] Coverage check passes
- [x] Security audit reports 0 vulnerabilities
- [x] ESLint, Prettier, Markdown lint, and link checks pass

Tested on macOS with Docker SQL Server.

## 📦 Dependencies

- [x] No new dependencies

## 🔍 Code Quality

- [x] Self-review completed
- [x] CodeRabbit review completed with no findings on tracked configuration changes
- [x] Regression test mutation-verified against mismatched CodeQL refs

## 📊 Performance Impact

- [x] No performance impact

## 📋 Deployment Notes

- [x] No special deployment requirements

## 🎯 Next Steps

After this PR is ready to merge, close superseded PRs #1047, #1048, and #1049.
